### PR TITLE
removing default timeout for runtime http calls

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -16,6 +16,7 @@ dependencies:
 - aeson
 - base >= 4.7 && < 5
 - bytestring
+- http-client
 - lens
 - monad-logger
 - mtl

--- a/src/AWS/Lambda/RuntimeClient.hs
+++ b/src/AWS/Lambda/RuntimeClient.hs
@@ -29,6 +29,7 @@ import           GHC.Generics
 import           Network.Wreq
 import           Network.Wreq.Session as S
 import           System.Environment
+import qualified Network.HTTP.Client as C
 
 newtype EventID = EventID String deriving (Show)
 type ErrorMessage = String
@@ -65,8 +66,12 @@ runtimeClient = do
   let
     runtimeHostEnv = "AWS_LAMBDA_RUNTIME_API"
     errorMsg = "Missing required environment variable \'AWS_LAMBDA_RUNTIME_API\'."
+    settings =
+      C.defaultManagerSettings {
+        C.managerResponseTimeout = C.responseTimeoutNone
+      }
   runtimeHost <- liftIO $ lookupEnv runtimeHostEnv
-  session     <- liftIO S.newAPISession
+  session     <- liftIO $ S.newSessionControl Nothing settings
   unless (isJust runtimeHost) ($(logErrorSH) errorMsg)
   let endpoints' = endpoints . (forceMaybe errorMsg) $ runtimeHost
   pure $


### PR DESCRIPTION
A quick fix to prevent timeouts on lambda when there are no queued
events to consume. Since the lambda runtime enforces a timeout on the
entire process, it should be safe to just wait for a response until a
new event is received or the process is halted.