### PR TITLE
generic api gateway event

### DIFF
--- a/examples/api-gateway/Main.hs
+++ b/examples/api-gateway/Main.hs
@@ -18,7 +18,10 @@ main = runStderrLoggingT $ do
   client <- runtimeClient
   forever $ echo client
 
-echo :: (MonadLogger m, MonadIO m) => RuntimeClient APIGatewayInputEvent APIGatewayOutputEvent m -> m ()
+type Runtime a =
+  RuntimeClient (APIGatewayInputEvent Text) APIGatewayOutputEvent a
+
+echo :: (MonadLogger m, MonadIO m) => Runtime m -> m ()
 echo RuntimeClient{..} = do
   Event{..} <- getNextEvent
   case eventBody of

--- a/src/AWS/Lambda/APIGatewayInputEvent.hs
+++ b/src/AWS/Lambda/APIGatewayInputEvent.hs
@@ -12,7 +12,7 @@ import Data.HashMap.Strict
 import Data.Text (Text)
 import GHC.Generics
 
-data APIGatewayInputEvent =
+data APIGatewayInputEvent a =
   APIGatewayInputEvent {
     resource                        :: Text
   , path                            :: Text
@@ -24,11 +24,11 @@ data APIGatewayInputEvent =
   , pathParameters                  :: Maybe (HashMap Text Text)
   , stageVariables                  :: Maybe (HashMap Text Text)
   , requestContext                  :: HashMap Text Value
-  , body                            :: Text
+  , body                            :: a
   , isBase64Encoded                 :: Bool
   } deriving (
     Generic
   , Show
   )
 
-instance FromJSON APIGatewayInputEvent
+instance FromJSON a => FromJSON (APIGatewayInputEvent a)


### PR DESCRIPTION
The body is actually a string, but could be any value that serializes to
a string. I think the most common use is probably a JSON value, so
making body generic, but constrained to `FromJSON`. Implementors would
need to write a FromJSON instance for whatever value they expect or
simply use `APIGatewayInputEvent Text`.