### PR TITLE
use a pre-built docker image for compiling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,14 @@
 FROM 137112412989.dkr.ecr.us-west-2.amazonaws.com/amazonlinux:2017.03.1.20170812@sha256:8b2b0d94a896c5f100ee60ad274bc7677e0038bc450642e6d142f503bb8ab9b8
-RUN yum install gcc gmp-devel zlib-devel xz shadow-utils.x86_64 -y
-RUN curl -sSL https://get.haskellstack.org/ | sh
+RUN yum install gcc gmp-devel zlib-devel xz shadow-utils.x86_64 perl -y && \
+  yum clean all
+ARG STACK_VERSION=1.9.3
+RUN curl -sSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz | \
+  tar xz --wildcards --strip-components=1 -C /usr/local/bin '*/stack'
+ARG GHC_VERSION=8.4.4
+RUN curl -sSL https://downloads.haskell.org/~ghc/$GHC_VERSION/ghc-$GHC_VERSION-x86_64-centos70-linux.tar.xz | \
+  tar xJ -C /tmp && cd /tmp/ghc-$GHC_VERSION && \
+  ./configure --prefix=/usr/local && \
+  make install
+ARG CABAL_VERSION=2.4.1.0
+RUN curl -sSL https://downloads.haskell.org/cabal/cabal-install-$CABAL_VERSION/cabal-install-$CABAL_VERSION-x86_64-unknown-linux.tar.xz | \
+  tar xJ -C /usr/local/bin cabal

--- a/README.md
+++ b/README.md
@@ -11,16 +11,7 @@ Examples of how to use this client can be found in the `examples` directory.
 1. [Stylish Haskell](https://github.com/jaspervdj/stylish-haskell)
 1. [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html)
 1. [SAM CLI](https://docs.aws.amazon.com/serverless-application-model/latest/developerguide/serverless-sam-cli-install.html)
-
-### Building in a Docker Container ###
-
-This project is built in a docker container that must be pulled from AWS ECR
-first.
-
-```
-$(aws ecr get-login --region us-west-2 --registry-ids 137112412989 --no-include-email)
-docker build --tag=aws-lambda-haskell-platform .
-```
+1. Get the docker image used for building: `stack docker pull`
 
 ## Building ##
 
@@ -31,6 +22,21 @@ build artifacts are in the `build` directory.
 ```
 make
 ```
+
+### Making Changes to the Build Environment ###
+
+Stack will build the defined executables in a docker container that is similar
+to the lambda environment the executable will run in. If you need to make
+changes to that environment (e.g. add a missing dependency that exists in the
+[AWS Lambda AMI](https://docs.aws.amazon.com/lambda/latest/dg/current-supported-versions.html)),
+update the Dockerfile and then rebuild the image. The base image is pulled from
+amazon, and requires that you login first.
+
+```
+$(aws ecr get-login --region us-west-2 --registry-ids 137112412989 --no-include-email)
+docker build --tag=earnestresearch/earnestresearch/aws-lambda-haskell-platform:lts-12.24 .
+```
+
 
 ## Deploy ##
 

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,5 +5,6 @@ packages:
 
 docker:
   enable: true
-  repo: aws-lambda-haskell-platform:latest
+  repo: earnestresearch/aws-lambda-haskell-platform:lts-12.24
   stack-exe: image
+


### PR DESCRIPTION
Switch to using an an image pulled from DockerHub rather than requiring
someone to login to AWS and build a new image from a Dockerfile. Specify
versions for stack (1.9.3), ghc (8.4.4), and cabal (2.4.1.0).