### PR TITLE
updating resolver to lts-13.11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,8 @@ RUN yum install gcc gmp-devel zlib-devel xz shadow-utils.x86_64 perl -y && \
 ARG STACK_VERSION=1.9.3
 RUN curl -sSL https://github.com/commercialhaskell/stack/releases/download/v$STACK_VERSION/stack-$STACK_VERSION-linux-x86_64.tar.gz | \
   tar xz --wildcards --strip-components=1 -C /usr/local/bin '*/stack'
-ARG GHC_VERSION=8.4.4
-RUN curl -sSL https://downloads.haskell.org/~ghc/$GHC_VERSION/ghc-$GHC_VERSION-x86_64-centos70-linux.tar.xz | \
+ARG GHC_VERSION=8.6.3
+RUN curl -sSL https://downloads.haskell.org/~ghc/$GHC_VERSION/ghc-$GHC_VERSION-x86_64-centos7-linux.tar.xz | \
   tar xJ -C /tmp && cd /tmp/ghc-$GHC_VERSION && \
   ./configure --prefix=/usr/local && \
   make install

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,10 @@
-resolver: lts-12.24
+resolver: lts-13.11
 
 packages:
 - .
 
 docker:
   enable: true
-  repo: earnestresearch/aws-lambda-haskell-platform:lts-12.24
+  repo: earnestresearch/aws-lambda-haskell-platform:lts-13.11
   stack-exe: image
 


### PR DESCRIPTION
Updating the stack resolver to `lts-13.11` and changing the stack configuration to use a new image with the appropriate tool versions installed.

Note: `lts-13.13` uses GHC `8.6.4` which seems to require a newer version of `libtinfo` than the amazon linux image has installed.