### PR TITLE
Aeson encoding

### DIFF
--- a/examples/dhall/Main.hs
+++ b/examples/dhall/Main.hs
@@ -1,16 +1,16 @@
-{-#LANGUAGE DeriveGeneric #-}
-{-#LANGUAGE DerivingVia #-}
-{-#LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE DerivingVia    #-}
 
 module Main where
 
-import AWS.Lambda.Handler
-import Dhall
 import AWS.Lambda.Encoding
+import AWS.Lambda.Handler
 import Control.Monad.Logger
+import Dhall
 
 data User = User {
-  name :: Text, 
+  name      :: Text,
   accountId :: Natural
 } deriving (Generic, Show, Interpret, Inject)
   deriving LambdaDecode via (LambdaFromDhall User)

--- a/examples/kinesis/Main.hs
+++ b/examples/kinesis/Main.hs
@@ -1,11 +1,11 @@
 module Main where
 
+import AWS.Lambda.Encoding
 import AWS.Lambda.Handler
 import AWS.Lambda.KinesisDataStreamsEvent
-import AWS.Lambda.Encoding
-import Control.Monad.Logger
-import Control.Monad.IO.Class
 import Control.Monad.Except
+import Control.Monad.IO.Class
+import Control.Monad.Logger
 
 main :: IO ()
 main = runStderrLoggingT $ handler echo

--- a/src/AWS/Lambda/APIGatewayInputEvent.hs
+++ b/src/AWS/Lambda/APIGatewayInputEvent.hs
@@ -1,15 +1,15 @@
 {-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE DerivingVia     #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DerivingVia #-}
 
 module AWS.Lambda.APIGatewayInputEvent where
 
+import AWS.Lambda.Encoding
 import Control.Lens
 import Data.Aeson
 import Data.HashMap.Strict
 import Data.Text (Text)
 import GHC.Generics
-import AWS.Lambda.Encoding
 
 
 data APIGatewayInputEvent = APIGatewayInputEvent
@@ -25,7 +25,7 @@ data APIGatewayInputEvent = APIGatewayInputEvent
   , _requestContext                  :: HashMap Text Value
   , _body                            :: Text
   , _isBase64Encoded                 :: Bool
-  } 
+  }
   deriving (Eq, Generic, Show)
   deriving LambdaDecode via (LambdaFromJSON APIGatewayInputEvent)
   deriving LambdaEncode via (LambdaToJSON APIGatewayInputEvent)

--- a/src/AWS/Lambda/APIGatewayOutputEvent.hs
+++ b/src/AWS/Lambda/APIGatewayOutputEvent.hs
@@ -1,16 +1,16 @@
-{-# LANGUAGE DeriveGeneric   #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# LANGUAGE DerivingVia       #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE TemplateHaskell   #-}
 
 module AWS.Lambda.APIGatewayOutputEvent where
 
+import AWS.Lambda.Encoding
 import Control.Lens
 import Data.Aeson
 import Data.HashMap.Strict
 import Data.Text (Text)
 import GHC.Generics
-import AWS.Lambda.Encoding
 
 apiGatewayOutputEvent :: Text -> APIGatewayOutputEvent
 apiGatewayOutputEvent = APIGatewayOutputEvent False 200 Nothing Nothing

--- a/src/AWS/Lambda/Encoding.hs
+++ b/src/AWS/Lambda/Encoding.hs
@@ -1,20 +1,20 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
-{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings          #-}
 
 module AWS.Lambda.Encoding where
+import           Control.Exception
 import qualified Data.Aeson as A
-import qualified Dhall as D
-import qualified Dhall.Core as DC
+import           Data.Bifunctor
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as BS8
 import qualified Data.ByteString.Lazy as LB
+import           Data.Coerce
 import qualified Data.Text as T
 import qualified Data.Text.Encoding as TE
 import qualified Data.Text.Lazy as LT
 import qualified Data.Text.Lazy.Encoding as LTE
-import qualified Data.ByteString as BS
-import qualified Data.ByteString.Char8 as BS8
-import Control.Exception
-import Data.Bifunctor
-import Data.Coerce
+import qualified Dhall as D
+import qualified Dhall.Core as DC
 
 class LambdaDecode e where
     decodeInput :: LB.ByteString -> IO (Either String e)
@@ -37,7 +37,7 @@ instance D.Interpret a => LambdaDecode (LambdaFromDhall a) where
     decodeInput = fmap showLeft . try . D.input D.auto . LT.toStrict . LTE.decodeUtf8 . decodeText
         where
             showLeft :: Either IOException b -> Either String b
-            showLeft = first show  
+            showLeft = first show
             decodeText :: LB.ByteString -> LB.ByteString
             decodeText = either (LTE.encodeUtf8 . LT.pack) LTE.encodeUtf8 . A.eitherDecode
 

--- a/src/AWS/Lambda/Handler.hs
+++ b/src/AWS/Lambda/Handler.hs
@@ -10,6 +10,7 @@ import           Control.Monad
 import           Control.Monad.Except
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
+import qualified Data.Aeson as A
 import           Data.Text
 import qualified Data.Text.Encoding as TE
 import qualified Data.ByteString.Lazy as LBS
@@ -26,5 +27,5 @@ handle c@RuntimeClient{..} f = do
   let 
     result = case eventBody of
       Right val -> f val >>= postResponse eventID
-      Left e    -> postError eventID (Error "Parse failure" $ pack e)
-  catchError result (postError eventID . Error "Error" . TE.decodeUtf8 . encodeOutput)
+      Left e    -> postError eventID (Error "Parse failure" $ (A.String . pack) e)
+  catchError result (postError eventID . Error "Error" . encodeOutput)

--- a/src/AWS/Lambda/Handler.hs
+++ b/src/AWS/Lambda/Handler.hs
@@ -11,10 +11,10 @@ import           Control.Monad.Except
 import           Control.Monad.IO.Class
 import           Control.Monad.Logger
 import qualified Data.Aeson as A
+import qualified Data.ByteString as BS
+import qualified Data.ByteString.Lazy as LBS
 import           Data.Text
 import qualified Data.Text.Encoding as TE
-import qualified Data.ByteString.Lazy as LBS
-import qualified Data.ByteString as BS
 
 handler :: (LambdaEncode err, MonadError err m, MonadIO m, MonadLogger m, LambdaDecode e, LambdaEncode r) => (e -> m r) -> m ()
 handler f = forever $ do
@@ -24,7 +24,7 @@ handler f = forever $ do
 handle :: (LambdaEncode err, MonadError err m, MonadIO m) => RuntimeClient e r m -> (e -> m r) -> m ()
 handle c@RuntimeClient{..} f = do
   event@Event{..} <- getNextEvent
-  let 
+  let
     result = case eventBody of
       Right val -> f val >>= postResponse eventID
       Left e    -> postError eventID (Error "Parse failure" $ (A.String . pack) e)

--- a/src/AWS/Lambda/HttpClient.hs
+++ b/src/AWS/Lambda/HttpClient.hs
@@ -27,7 +27,7 @@ instance HttpResponse (W.Response body) body where
 data HttpClient a =
   HttpClient {
     get  :: (HttpResponse a LB.ByteString) => String -> IO a
-  , post :: (HttpResponse a LB.ByteString) => String -> SB.ByteString -> IO a
+  , post :: (HttpResponse a LB.ByteString) => String -> Value -> IO a
   }
 
 defaultHttpClient :: IO (HttpClient (W.Response LB.ByteString))

--- a/src/AWS/Lambda/KinesisDataStreamsEvent.hs
+++ b/src/AWS/Lambda/KinesisDataStreamsEvent.hs
@@ -1,16 +1,16 @@
-{-# LANGUAGE DeriveGeneric   #-}
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE DeriveGeneric      #-}
+{-# LANGUAGE DerivingVia        #-}
+{-# LANGUAGE RecordWildCards    #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE TemplateHaskell    #-}
 
 module AWS.Lambda.KinesisDataStreamsEvent where
 
+import AWS.Lambda.Encoding
 import Control.Lens
 import Data.Aeson
 import Data.Text (Text)
 import GHC.Generics
-import AWS.Lambda.Encoding
 
 data Kinesis = Kinesis
   { _partitionKey         :: Text

--- a/src/AWS/Lambda/RuntimeClient.hs
+++ b/src/AWS/Lambda/RuntimeClient.hs
@@ -1,12 +1,12 @@
+{-# LANGUAGE DeriveAnyClass             #-}
 {-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DerivingVia                #-}
 {-# LANGUAGE FlexibleContexts           #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings          #-}
 {-# LANGUAGE RankNTypes                 #-}
 {-# LANGUAGE RecordWildCards            #-}
 {-# LANGUAGE TemplateHaskell            #-}
-{-# LANGUAGE DerivingVia            #-}
-{-# LANGUAGE DeriveAnyClass            #-}
 
 module AWS.Lambda.RuntimeClient
   ( runtimeClient
@@ -17,7 +17,9 @@ module AWS.Lambda.RuntimeClient
   , EventID
   ) where
 
+import           AWS.Lambda.Encoding
 import           AWS.Lambda.HttpClient
+import           AWS.Lambda.Types
 import           Control.Lens
 import           Control.Monad
 import           Control.Monad.IO.Class
@@ -29,8 +31,6 @@ import           Data.Maybe
 import           Data.Text (Text)
 import           GHC.Generics
 import           System.Environment
-import AWS.Lambda.Encoding
-import AWS.Lambda.Types
 
 data RuntimeClient e r m =
   RuntimeClient {
@@ -85,7 +85,7 @@ getNextEvent' ::
 getNextEvent' Endpoints{..} HttpClient{..} = do
   response <- liftIO $ get nextURL
   setTraceID response
-  eventID  <- parseEventID response 
+  eventID  <- parseEventID response
   eventBody <- parseEvent response
   pure $ Event eventID eventBody
 

--- a/src/AWS/Lambda/S3Event.hs
+++ b/src/AWS/Lambda/S3Event.hs
@@ -1,22 +1,22 @@
 {-# LANGUAGE DeriveAnyClass  #-}
 {-# LANGUAGE DeriveGeneric   #-}
+{-# LANGUAGE DerivingVia     #-}
 {-# LANGUAGE TemplateHaskell #-}
-{-# LANGUAGE DerivingVia #-}
 
 module AWS.Lambda.S3Event where
 
+import AWS.Lambda.Encoding
 import Control.Lens
 import Data.Aeson
 import Data.HashMap.Strict
 import Data.Text hiding (drop)
 import GHC.Generics
-import AWS.Lambda.Encoding
 
 newtype S3Event = S3Event { _records :: [Record] }
   deriving (Eq, Generic, Show)
   deriving LambdaDecode via (LambdaFromJSON S3Event)
   deriving LambdaEncode via (LambdaToJSON S3Event)
-  
+
 instance ToJSON S3Event where
   toJSON = genericToJSON defaultOptions { fieldLabelModifier = modify }
 

--- a/src/AWS/Lambda/SNSEvent.hs
+++ b/src/AWS/Lambda/SNSEvent.hs
@@ -1,19 +1,19 @@
 {-# LANGUAGE DeriveAnyClass        #-}
 {-# LANGUAGE DeriveGeneric         #-}
+{-# LANGUAGE DerivingVia           #-}
 {-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE StandaloneDeriving    #-}
 {-# LANGUAGE TemplateHaskell       #-}
-{-# LANGUAGE DerivingVia #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 module AWS.Lambda.SNSEvent where
 
+import           AWS.Lambda.Encoding
 import           Control.Lens
 import           Data.Aeson
 import qualified Data.Char as C
 import           Data.HashMap.Strict
 import           Data.Text hiding (drop)
 import           GHC.Generics
-import AWS.Lambda.Encoding
 
 newtype SNSEvent = SNSEvent { _records :: [Record] }
   deriving (Eq, Generic, Show)

--- a/src/AWS/Lambda/Types.hs
+++ b/src/AWS/Lambda/Types.hs
@@ -23,7 +23,7 @@ data Event a =
 data Error =
   Error {
     errorType    :: Text
-  , errorMessage :: Text
+  , errorMessage :: Value
   } deriving (
     Show,
     Generic,

--- a/src/AWS/Lambda/Types.hs
+++ b/src/AWS/Lambda/Types.hs
@@ -1,13 +1,13 @@
-{-# LANGUAGE DerivingVia            #-}
-{-# LANGUAGE DeriveAnyClass            #-}
-{-# LANGUAGE DeriveGeneric              #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric  #-}
+{-# LANGUAGE DerivingVia    #-}
 
 module AWS.Lambda.Types where
 
 import AWS.Lambda.Encoding
-import GHC.Generics
 import Data.Aeson
 import Data.Text
+import GHC.Generics
 
 newtype EventID = EventID String deriving (Show)
 type ErrorMessage = String


### PR DESCRIPTION
This PR makes the runtime always return the output as a valid JSON value as this is the most common use case of all and stuff like Step Functions always assume this to be true. This is a bit unfortunate as other formats have to be string-encoded and decoded but we still keep the nice machinery of LambdaEncode and Decode to make it as easy as possible.

Note: actual changes are in https://github.com/EarnestResearch/aws-lambda-haskell-runtime-client/commit/f5dcbab81a4373d16346cbb72a30ccf07ca27713
The other commit is just the formatting tool that finally picks on deriving via :) 