### PR TITLE
Clarify usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ To create a lambda that is based on this library, using `stack`:
 extra-deps:
   - github: EarnestResearch/yambda
     commit: {commit-sha}
+    subdirs:
+      - core
+      - wai
 ```
 2. Add it to your `package.yaml`
 


### PR DESCRIPTION
Without specifying subdirs, you get a nasty error message

```
The path name '.nix' is invalid: it is illegal to start the name with a period. Path names are alphanumeric and can include the symbols +-._?= and must not begin with a period. Note: If '.nix' is a source file and you cannot rename it on disk, builtins.path { name = ... } can be used to give it an alternative name.
```

when trying to build with Stack/Nix
